### PR TITLE
fix duplicate declarations in php.ini

### DIFF
--- a/build/wordpress/nginx-php7-fpm/php.ini
+++ b/build/wordpress/nginx-php7-fpm/php.ini
@@ -403,10 +403,6 @@ max_input_vars = 10000
 ; http://php.net/memory-limit
 memory_limit = 256M
 
-post_max_size = 100M
-
-upload_max_filesize = 64M
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -674,7 +670,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 100M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -827,7 +823,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 64M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
I made a mistake in #1, resulting in multiple declarations of `post_max_size` and `upload_max_filesize`. This should fix that, setting the desired value in the correct place and removing the duplicates that I added.