### PR TITLE
set `client_max_body_size` in nginx config

### DIFF
--- a/build/wordpress/nginx-php7-fpm/nginx.conf
+++ b/build/wordpress/nginx-php7-fpm/nginx.conf
@@ -54,6 +54,8 @@ http {
   fastcgi_pass_header Set-Cookie;
   fastcgi_pass_header Cookie;
 
+  client_max_body_size 100m;
+
   # Update charset_types due to updated mime.types
   charset_types text/css text/plain text/vnd.wap.wml application/javascript application/json application/rss+xml application/xml;
 


### PR DESCRIPTION
The default value of 1m was preventing uploading larger files into WordPress, despite the 64M PHP upload limit.